### PR TITLE
Replace deprecated std::auto_ptr with std::unique_ptr

### DIFF
--- a/include/olestem/indexing/string_util.h
+++ b/include/olestem/indexing/string_util.h
@@ -296,7 +296,7 @@ namespace string_util
         size_t strPos = 0;
         int intValue = 0;
         //storage for converted values
-        int* digits = new int[length+1]; std::auto_ptr<int> digitsDeleter(digits);
+        int* digits = new int[length+1]; std::unique_ptr<int> digitsDeleter(digits);
         std::memset(digits, 0, sizeof(int)*(length+1));
         while (strPos < length)
             {


### PR DESCRIPTION
Hi Oleander, 

std::auto_ptr has been deprecated in C++11 and has been removed in C++17. I replaced it with std::unique_ptr, which still ensures the variable int *digits will be deleted when it goes out of scope.

Best, 
Xoltus